### PR TITLE
Added Wallet to gitignore

### DIFF
--- a/cinema-ebooking-system/.gitignore
+++ b/cinema-ebooking-system/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+*Wallet*


### PR DESCRIPTION
Added `*Wallet*` to .gitignore so that the Oracle Wallet doesn't get pushed to the repo as it holds admin creds.